### PR TITLE
Changed recursive file lookups for Windows paths support

### DIFF
--- a/rules/exists.js
+++ b/rules/exists.js
@@ -12,7 +12,7 @@ var BUNDLED_MODULES = [
 ];
 
 function findInParents(absolutePath, targetFile) {
-  var addSeparator = absolutePath[0] == path.sep;
+  var addSeparator = absolutePath.charAt(0) == path.sep;
   var current = absolutePath.split(path.sep).filter(Boolean);
   var pathname;
   while (current.length) {

--- a/rules/exists.js
+++ b/rules/exists.js
@@ -11,19 +11,18 @@ var BUNDLED_MODULES = [
   'smalloc', 'stream', 'string_decoder', 'sys', 'timers', 'tls', 'tty', 'url', 'util', 'vm', 'zlib'
 ];
 
-function getModulesDir(fromDir) {
-  if (!fs.existsSync(fromDir)) {
-    return null;
-  }
-
-  var current = fromDir.split(path.sep).filter(Boolean);
+function findInParents(absolutePath, targetFile) {
+  var addSeparator = absolutePath[0] == path.sep;
+  var current = absolutePath.split(path.sep).filter(Boolean);
   var pathname;
-
-
   while (current.length) {
-    pathname = path.sep + current.join(path.sep);
-    if (fs.readdirSync(pathname).indexOf('package.json') >= 0) {
-      return path.join(pathname, 'node_modules');
+    pathname = current.join(path.sep);
+    if (addSeparator) {
+      pathname = path.sep + pathname;
+    }
+    console.log(path.sep, pathname);
+    if (fs.readdirSync(pathname).indexOf(targetFile) >= 0) {
+      return pathname;
     }
 
     current.pop();
@@ -31,6 +30,20 @@ function getModulesDir(fromDir) {
 
   return null;
 }
+
+function getModulesDir(fromDir) {
+  if (!fs.existsSync(fromDir)) {
+    return null;
+  }
+  var pathname = findInParents(fromDir, "package.json");
+
+  if (pathname !== null) {
+    return path.join(pathname, 'node_modules');
+  }
+
+  return null;
+}
+
 
 function resolveModule(value, fromDir, modulesDir) {
   var pathname = url.parse(value).pathname;
@@ -108,17 +121,10 @@ function getWebpackConfig(fromDir) {
     return {};
   }
 
-  var current = fromDir.split(path.sep).filter(Boolean);
-  var pathname;
+  var pathname = findInParents(fromDir, "webpack.config.js");
 
-  while (current.length) {
-    pathname = path.sep + current.join(path.sep);
-
-    if (fs.readdirSync(pathname).indexOf('webpack.config.js') >= 0) {
-      return require(path.join(pathname, 'webpack.config.js'));
-    }
-
-    current.pop();
+  if (pathname !== null) {
+    return require(path.join(pathname, 'webpack.config.js'));
   }
 
   return {};


### PR DESCRIPTION
Hi,

due to the leading C:\ in Windows paths, this plugin fails when looking for a file (it is looking for C:\C:\path as a backward slash is added at the beginning). I've fixed this by checking if the system separator if the first char in the path. 
