### PR TITLE
Eslint absolute path support

### DIFF
--- a/rules/exists.js
+++ b/rules/exists.js
@@ -105,7 +105,12 @@ function isAtom() {
 
 function getCurrentFilePath(context) {
   if (!isAtom()) {
-    return path.dirname(path.join(process.cwd(), context.getFilename()));
+    var filename = context.getFilename();
+    if (path.isAbsolute(filename)) {
+      return path.dirname(filename);
+    } else {
+      return path.dirname(path.join(process.cwd(), context.getFilename()));
+    }
   }
 
   // TODO: we need this hack until https://github.com/AtomLinter/linter-eslint/pull/89 will be merged


### PR DESCRIPTION
Fixed current file path lookup for calls to ESLint with an absolute path (ie. emacs)
