### PR TITLE
support plugin:require-path-exists/recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ This repository will give access to new rules for the ESLint tool. You should us
     npm install --save-dev eslint-plugin-require-path-exists
     ```
 
-2. Enable the plugin by adding it to your `.eslintrc`:
+2. Enable the plugin by adding it to the `plugins` and start from default (recommended) configuration in `extends` in `.eslintrc`:
 
     ```js
     {
+      "extends": [
+        "plugin:require-path-exists/recommended"
+      ],
       "plugins": [
         "require-path-exists"
       ]

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,16 @@ export default {
   rulesConfig: {
     notEmpty: 2,
     tooManyArguments: 2,
-    exists: [ 2, { extensions: [ '', '.js', '.json', '.node' ] }]
-  }
+    exists: [ 2, { extensions: [ '', '.js', '.json', '.node' ] }] 
+  },
+  configs: {
+    recommended: {
+      plugins: ['require-path-exists'],
+      rules: {
+        notEmpty: 2,
+        tooManyArguments: 2,
+        exists: [ 2, { extensions: [ '', '.js', '.json', '.node' ] }] 
+      },
+    },
+  },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,19 +8,14 @@ export default {
     tooManyArguments,
     exists
   },
-  rulesConfig: {
-    notEmpty: 2,
-    tooManyArguments: 2,
-    exists: [ 2, { extensions: [ '', '.js', '.json', '.node' ] }] 
-  },
   configs: {
     recommended: {
       plugins: ['require-path-exists'],
       rules: {
-        notEmpty: 2,
-        tooManyArguments: 2,
-        exists: [ 2, { extensions: [ '', '.js', '.json', '.node' ] }] 
-      },
-    },
-  },
+        'require-path-exists/notEmpty': 2,
+        'require-path-exists/tooManyArguments': 2,
+        'require-path-exists/exists': [ 2, { extensions: ['', '.js', '.json', '.node'] }] 
+      }
+    }
+  }
 };


### PR DESCRIPTION
if one just add it into plugins list it wont work, one need either to specify rules on their own, or extend with recommended, like in react-plugin-react https://github.com/yannickcr/eslint-plugin-react#shareable-configurations